### PR TITLE
Version 2.0.2: Ignore 'inherit' fonts and non-screen stylesheets

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -10,7 +10,13 @@ const extractFontFamilyRules = () =>
 
   for (const sheet of document.styleSheets) {
 
+    // Ignore the styles set by this extention.
     if (sheet.ownerNode.id == extentionStyleTagId) 
+      continue;
+
+    // Ignore any non-screen stylesheets.
+    const sheetMediaBlacklist = ['print', 'speech', 'aural', 'braille', 'handheld', 'projection', 'tty'];
+    if (sheetMediaBlacklist.includes(sheet.media.mediaText))
       continue;
 
     try {
@@ -23,6 +29,10 @@ const extractFontFamilyRules = () =>
 
         const selectorText = rule.selectorText;
         const fontFamily = rule.style.fontFamily;
+
+        // The 'inherit' value cannot be combined with other fonts; ignore it.
+        if (fontFamily == 'inherit')
+          continue;
 
         // Already modified CSS selectors may be ignored.
         if (fontFamily.toLowerCase().includes(replacementFontName.toLowerCase())) 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "name": "Country Flag Fixer",
     "default_locale": "en",
     "description": "__MSG_extDesc__",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "manifest_version": 3,
     "content_scripts": [
         {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-country-flags",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Replaces mysterious abbreviations automatically with the corresponding flag. The solution for Chromium users on Windows!",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes a bug where in certain scenarios original fonts are not correctly loading. A specific example is https://archiveofourown.org/ where rules from `<link media="print" [...]>` stylesheets  were also updated, which caused rendering the print-only fonts on screen:

**Expected result**:
![image](https://github.com/matthijs110/chromium-country-flags/assets/4161158/fe5deeff-3420-4f3a-bf59-61e2ac44b485)

**Actual result:**
![image](https://github.com/matthijs110/chromium-country-flags/assets/4161158/fa1b4739-bf70-4d8c-a99a-c48950afecb4)
