### PR TITLE
Fetch CSS files that can't be accessed directly

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -4,11 +4,86 @@ const replacementFontName = "Twemoji Country Flags";
 // The id the element containing all overwritten font families.
 const extentionStyleTagId = "country-flag-fixer-ext";
 
-const extractFontFamilyRules = () => 
+// Logging settings
+const logsEnabled = true;
+const logPrefix = "[FLAG-FIXER]";
+let runCount = 0;
+
+// Keeping track of the CSS files that have been requested to avoid duplicates
+const requestedCssFiles = new Set();
+
+
+// ---------------------------- Logging functions ---------------------------- //
+const log = (message, subTaskCount=null, totalSubTasks=null, subPrefix='S') => {
+  if (!logsEnabled)
+    return;
+
+  let msg = `${logPrefix} [R:${runCount}`;
+  if (subTaskCount != null)
+    msg += ` ${subPrefix}:${subTaskCount}`;
+  if (totalSubTasks != null)
+    msg += `/${totalSubTasks}`;
+  msg += `] ${message}`;
+
+  console.log(msg);
+}
+
+const logError = (message, error, subTaskCount=null, totalSubTasks=null, subPrefix='S') => {
+  if (!logsEnabled)
+    return;
+
+  let msg = `${logPrefix} [R:${runCount}`;
+  if (subTaskCount != null)
+    msg += ` ${subPrefix}:${subTaskCount}`;
+  if (totalSubTasks != null)
+    msg += `/${totalSubTasks}`;
+  msg += `] ${message}`;
+
+  console.error(msg, error);
+}
+
+
+// ----------------------------- Main functions ----------------------------- //
+const fetchCSSRulesFromUrl = async (styleHref) => {
+  log(`Fetching CSS rules from: ${styleHref}`);
+
+  const preloadLink = document.querySelector(`link[href="${styleHref}"]`);
+  if (!preloadLink) {
+      logError(`Preload link not found for URL: ${styleHref}`);
+      return [];
+  }
+
+  try {
+    const response = await fetch(styleHref);
+    const cssText = await response.text();
+    
+    // Create a temporary style element
+    const style = document.createElement(`style`);
+    style.textContent = cssText;
+    const id = Math.random().toString(36).substring(7);
+    style.id = id;
+    document.head.appendChild(style);
+    
+    // Get rules from the temporary stylesheet
+    const rules = Array.from(style.sheet.cssRules);
+    
+    // Clean up
+    document.head.removeChild(style);
+    
+    return rules;
+  } catch (error) {
+      logError(`Error fetching CSS:`, error);
+      return [];
+  }
+}
+
+const updateFontFamilyRules = async () =>
 {
-  const fontFamilyRules = [];
+  let sheetCount = 0;
 
   for (const sheet of document.styleSheets) {
+    const fontFamilyRules = [];
+    log("Processing sheet", ++sheetCount, document.styleSheets.length);
 
     // Ignore the styles set by this extention.
     if (sheet.ownerNode.id == extentionStyleTagId) 
@@ -20,11 +95,24 @@ const extractFontFamilyRules = () =>
       continue;
 
     try {
-      
-      // Loop through every CSS selector in the stylesheet
-      for (const rule of sheet.cssRules) {
 
-        if (!rule.style || !rule.style?.fontFamily) 
+      // 1. Retreive the CCS rules - either directly from the stylesheet or fetched from URL
+      let cssRules = [];
+      try {
+        cssRules = sheet.cssRules;
+      } catch (error) {
+        if (!sheet.href || sheet.ownerNode.rel !== "stylesheet" || requestedCssFiles.has(sheet.href)) 
+          continue;
+
+        cssRules = await fetchCSSRulesFromUrl(sheet.href);
+        requestedCssFiles.add(sheet.href);
+        log(`✅ Fetched CSS! - ${cssRules.length} rules`, sheetCount, document.styleSheets.length);
+      }
+      
+      // 2. Loop through every CSS selector in the stylesheet
+      for (const rule of cssRules) {
+
+        if (!rule.style || !rule.style?.fontFamily || !rule.selectorText) 
           continue;
 
         const selectorText = rule.selectorText;
@@ -35,25 +123,39 @@ const extractFontFamilyRules = () =>
           continue;
 
         // Already modified CSS selectors may be ignored.
-        if (fontFamily.toLowerCase().includes(replacementFontName.toLowerCase())) 
+        if (fontFamily.toLowerCase().includes(replacementFontName.toLowerCase()))
           continue;
 
+        log(`Added rule for: ${selectorText}`, fontFamilyRules.length, subPrefix='F');
         fontFamilyRules.push({ selectorText, fontFamily });
       }
-    }
-    catch (e) {
-      // Some stylesheets might not be accessible due to CORS restrictions; ignore them.
+
+      // 3. Update the style tag with the new rules
+      updateStyleTag(fontFamilyRules);
+
+    } catch (error) {
+      // Some stylesheets might not be accessible due to CORS restrictions; log the error and continue.
+      logError(`Error retrieving font-family rules`, error, sheetCount, document.styleSheets.length);
     }
   }
 
-  return fontFamilyRules;
+  log(`💯 Finished looping through ${document.styleSheets.length} CSS rules`);
 };
 
-const createNewStyleTag = (fontFamilyRules) => 
+const createNewStyleTag = (fontFamilyRules, existingSheet = null) =>
 {
   const style = document.createElement("style");
   style.setAttribute("type", "text/css");
   style.setAttribute("id", extentionStyleTagId);
+
+  // Add old rules to new tag
+  let oldRules = existingSheet ? Array.from(existingSheet.sheet.cssRules) ?? [] : [];
+  oldRules.forEach((rule) => {
+    style.textContent += rule.cssText + "\n";
+  });
+
+  // Ensure new rules 
+  fontFamilyRules = fontFamilyRules.filter(rule => !oldRules.some(old => old.selectorText === rule.selectorText));
 
   fontFamilyRules.forEach((rule) => {
     // Set the Country Flags font as main property; set the original font(s) as 'fallback'
@@ -63,25 +165,26 @@ const createNewStyleTag = (fontFamilyRules) =>
   return style;
 };
 
-const applyCustomFontStyles = () => 
+const updateStyleTag = (fontFamilyRules) =>
 {
-  var existingSheet = document.getElementById(extentionStyleTagId);
+  const existingSheet = document.getElementById(extentionStyleTagId);
 
-  const fontFamilyRules = extractFontFamilyRules();
-  const newStyleTag = createNewStyleTag(fontFamilyRules);
+  const newStyleTag = createNewStyleTag(fontFamilyRules, existingSheet);
 
+  log(`Updating style tag: ${newStyleTag.textContent.length} characters`);
+  
   // Completely rewrite the overriden styles, if applicable.
   if (existingSheet) {
     existingSheet.parentNode.removeChild(existingSheet);
   }
-
+  
   if (document.head == null) 
     return;
 
   document.head.appendChild(newStyleTag);
 };
 
-const preserveCustomFonts = (element) => 
+const preserveCustomFonts = (element) =>
 {
   if (element == undefined)
     return;
@@ -107,21 +210,20 @@ const preserveCustomFonts = (element) =>
   element.style.setProperty('font-family', currentFontFamily, 'important');
 }
 
-// Observe the document for dynamically added styles
-let lastStyleSheets = new Set(Array.from(document.styleSheets).map(sheet => sheet.href || sheet.ownerNode.textContent));
-const observer = new MutationObserver((mutations) => 
+const lastStyleSheets = new Set(Array.from(document.styleSheets).map(sheet => sheet.href || sheet.ownerNode.textContent));
+const styleSheetsChanged = (mutations) =>
 {
   let stylesheetChanged = false;
 
-  mutations.forEach(mutation => 
+  mutations.forEach(mutation =>
   {
     // Only focus on <link> and <style> elements.
-    mutation.addedNodes.forEach(node => 
+    mutation.addedNodes.forEach(node =>
     {
       if (node.id === extentionStyleTagId)
         return;
 
-      const isStylesheet = node.nodeName === 'LINK' && node.rel === 'stylesheet';
+      const isStylesheet = node.nodeName === 'LINK' && (node.rel === 'stylesheet' || node.as === 'style');
       const isStyleNode = node.nodeName === 'STYLE'
       if (!isStylesheet && !isStyleNode)
         return;
@@ -135,8 +237,16 @@ const observer = new MutationObserver((mutations) =>
     });
   });
 
-  if (stylesheetChanged) {
-    applyCustomFontStyles();
+  return stylesheetChanged;
+}
+
+
+// Observe the document for dynamically added styles
+const observer = new MutationObserver(async (mutations) => {
+  if (styleSheetsChanged(mutations)) {
+    log(`Running Country Flag Fixer`);
+    await updateFontFamilyRules();
+    runCount++;
   }
 
   // Preserve font families set using the style attribute on any HTML element.

--- a/src/content.js
+++ b/src/content.js
@@ -5,7 +5,7 @@ const replacementFontName = "Twemoji Country Flags";
 const extentionStyleTagId = "country-flag-fixer-ext";
 
 // Logging settings
-const logsEnabled = true;
+const logsEnabled = false;
 const logPrefix = "[FLAG-FIXER]";
 let runCount = 0;
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "name": "Country Flag Fixer",
     "default_locale": "en",
     "description": "__MSG_extDesc__",
-    "version": "2.0.2",
+    "version": "2.1.0",
     "manifest_version": 3,
     "content_scripts": [
         {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,12 +7,14 @@
     "content_scripts": [
         {
             "matches": ["<all_urls>"],
+            "exclude_matches": ["*://www.youtube.com/*", "*://www.linkedin.com/*"],
             "js": ["content_head.js"],
             "run_at": "document_idle",
             "all_frames": true
         },
         {
             "matches": ["<all_urls>"],
+            "exclude_matches": ["*://www.youtube.com/*", "*://www.linkedin.com/*"],
             "js": ["content.js"],
             "run_at": "document_start",
             "all_frames": true

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-country-flags",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Replaces mysterious abbreviations automatically with the corresponding flag. The solution for Chromium users on Windows!",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #18, #16, #14, #10, #8.

## Context

When investigating #18, I found that CSS files that are linked linked with `rel="preload"`, didn't appear to have their font-family overrides correctly added to the `#country-flag-fixer-ext` style tag that the extension adds. For example:
```html
<link as="style" href="https://assets.quizlet.com/_next/static/css/c942139eed6c8f57.css" rel="preload">
```

In particular, I found the script failed at [line 25](https://github.com/matthijs110/chromium-country-flags/blob/master/src/content.js#L25) of `content.js`, and debugging in dev tools, it looks like these `rel="preload"` css files for whatever reason don't let you use `sheet.cssRules` (like line 25 uses).

So I added in a try/catch ([here](https://github.com/matthijs110/chromium-country-flags/pull/19/files#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fR100)) that first tries to read the rules with `sheet.cssRules`, and if this fails, then it will try to retrieve the CSS file directly from the href (new function `fetchCSSRulesFromUrl`).

This is the core of the change which gets the missed styles added into the `#country-flag-fixer-ext` style tag.

Other changes done alongside this change:
- Togglable logging functionality to help with debugging
- Changing how often the `#country-flag-fixer-ext` tag is updated:
   - Now updates once per CSS sheet as opposed to once per mutation cycle
   - Before removing the old `#country-flag-fixer-ext` tag, its existing `cssRules` are read, added to the new tag, and _then_ the new CSS rules are added
   - I did this because I found if I didn't, a CSS file would get read correctly, and the rules would be ready to add to `#country-flag-fixer-ext`, but then if there was a CORS or some other error trying to read a later CSS file, this would error and exit the whole process meaning the rules from the previously successfully read file wouldn't be added
   - This now means the main function the observer calls is `updateFontFamilyRules()` instead of `applyCustomFontStyles()`
- Pulling out `styleSheetsChanged` into its own function

## Testing

This fix works for nearly all the broken sites mentioned in current issues except Bluesky.

Checked against the following URLs. Screenshots below.
- Quizlet - #18: 
  - https://quizlet.com/user/pjpscriv/folders/peters-french-1
- Strava - #16 #14: 
  - https://www.strava.com/athletes/3972456
- Letterboxed - #8: 
  - [https://letterboxd.com/search/🇵🇸+🇺🇸+🇧🇷+🇩🇪/](https://letterboxd.com/search/%F0%9F%87%B5%F0%9F%87%B8+%F0%9F%87%BA%F0%9F%87%B8+%F0%9F%87%A7%F0%9F%87%B7+%F0%9F%87%A9%F0%9F%87%AA/)
- Old reddit #10 : 
  - https://old.reddit.com/r/Windows11/comments/upjpj9/flag_emojis/
- Bluesky - #9 : 
  - https://bsky.app/profile/pjpscriv.com
- Emojipedia for completeness: 
  - https://emojipedia.org/flag-aland-islands

<details>
  <summary>Quizlet ✅</summary>

  ![image](https://github.com/user-attachments/assets/9ef1c141-49f5-4cd0-959f-d818293e8181)

</details>

<details>
  <summary>Strava ✅</summary>

  ![image](https://github.com/user-attachments/assets/b5ec3ca1-a6cf-4a7c-9429-6b425340e96d)

</details>

<details>
  <summary>Letterboxed ✅</summary>

  ![image](https://github.com/user-attachments/assets/28012b5f-2358-458e-9c2a-271dd15d1229)

</details>

<details>
  <summary>Old reddit ✅</summary>

  ![image](https://github.com/user-attachments/assets/d05aa33a-4605-40d5-84b5-f4b54de4cfb2)

</details>

<details>
  <summary>Bluesky ❌</summary>

  ![image](https://github.com/user-attachments/assets/211970e9-b9b8-47a9-b25a-e7d1f73e5cd6)

</details>

<details>
  <summary>Emojipedia ✅</summary>

  ![image](https://github.com/user-attachments/assets/0bee90e6-01fa-439e-887d-f91b4aace4cb)

</details>